### PR TITLE
Fixing security vulnerability in package deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ cache:
 notifications:
   email: false
 node_js:
-  - '10'
+  - '9'
 
 script: npm run ci

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@babel/cli": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.0.0-beta.55.tgz",
-      "integrity": "sha1-rGWLJUEDy15ZuhPmYqYXSEIHCzM=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.0.0-beta.56.tgz",
+      "integrity": "sha512-K7x9x0kRHwnSAX5JC0SL8rjjZelUqGCQ30dM383mCj/zgGG2MVv9TQ8SSHzvXIfXKEemZGIp9LLckVjFFnaNmg==",
       "dev": true,
       "requires": {
         "chokidar": "^2.0.3",
@@ -23,27 +23,27 @@
       }
     },
     "@babel/code-frame": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.55.tgz",
-      "integrity": "sha1-cfUw57AQr163p993UveJId1X6e4=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.56.tgz",
+      "integrity": "sha512-OBeGs8UXWpKl0oK2T5nUXNl2yu8RKxqL/7aUnMtKDXCU6VUrNP3npdrPivBA11HPB15TVI49nWf2lntTzoUuAg==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "7.0.0-beta.55"
+        "@babel/highlight": "7.0.0-beta.56"
       }
     },
     "@babel/core": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.0.0-beta.55.tgz",
-      "integrity": "sha1-nhfDS1rIVeQnyY9XCRWhf8xrq0o=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.0.0-beta.56.tgz",
+      "integrity": "sha512-IsytpdHZqo5pgJj4FTcpEMKmfXK9TdvThLZo4yUOjbuVZCy8NAwoeBnojvKCNf+139L7xNIIosp3RVA0cMkbOg==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.0.0-beta.55",
-        "@babel/generator": "7.0.0-beta.55",
-        "@babel/helpers": "7.0.0-beta.55",
-        "@babel/parser": "7.0.0-beta.55",
-        "@babel/template": "7.0.0-beta.55",
-        "@babel/traverse": "7.0.0-beta.55",
-        "@babel/types": "7.0.0-beta.55",
+        "@babel/code-frame": "7.0.0-beta.56",
+        "@babel/generator": "7.0.0-beta.56",
+        "@babel/helpers": "7.0.0-beta.56",
+        "@babel/parser": "7.0.0-beta.56",
+        "@babel/template": "7.0.0-beta.56",
+        "@babel/traverse": "7.0.0-beta.56",
+        "@babel/types": "7.0.0-beta.56",
         "convert-source-map": "^1.1.0",
         "debug": "^3.1.0",
         "json5": "^0.5.0",
@@ -65,12 +65,12 @@
       }
     },
     "@babel/generator": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.55.tgz",
-      "integrity": "sha1-jsERUtzDmLrjXdGBEicEQVw4OgE=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.56.tgz",
+      "integrity": "sha512-d+Ls/Vr5OU5FBDYQToXSqAluI3r2UaSoNZ41zD3sxdoVoaT8K5Bdh4So4eG4o//INGM7actValXGfb+5J1+r8w==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.0.0-beta.55",
+        "@babel/types": "7.0.0-beta.56",
         "jsesc": "^2.5.1",
         "lodash": "^4.17.10",
         "source-map": "^0.5.0",
@@ -78,224 +78,224 @@
       }
     },
     "@babel/helper-annotate-as-pure": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0-beta.55.tgz",
-      "integrity": "sha1-PD5MAOFOfeqReTjjXtXZFWzdNc4=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0-beta.56.tgz",
+      "integrity": "sha512-PaHQ8R489lwBZYz/F81YpKDurIQfKWliNIpHZAysYbnozq8hVyaUx8D5wW6Dplf0lUUQ8Y/I3YKtiNoyg7bLHA==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.0.0-beta.55"
+        "@babel/types": "7.0.0-beta.56"
       }
     },
     "@babel/helper-builder-binary-assignment-operator-visitor": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.0.0-beta.55.tgz",
-      "integrity": "sha1-TQISis/1w2ii1D6oYIJgzkmu7F0=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.0.0-beta.56.tgz",
+      "integrity": "sha512-ka5Fe6UB/jRtCWU/emg6fLKqttaVaBCF1zdT06PYs7w8hJPidCcfdVMBoDHfqL3pgLo+hp+LW4Q/99zw/zv0Sw==",
       "dev": true,
       "requires": {
-        "@babel/helper-explode-assignable-expression": "7.0.0-beta.55",
-        "@babel/types": "7.0.0-beta.55"
+        "@babel/helper-explode-assignable-expression": "7.0.0-beta.56",
+        "@babel/types": "7.0.0-beta.56"
       }
     },
     "@babel/helper-builder-react-jsx": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.0.0-beta.55.tgz",
-      "integrity": "sha1-n170Q+NhDPi+RQaFy8NlhIDPzY8=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.0.0-beta.56.tgz",
+      "integrity": "sha512-s7nY9YbY+/6yccMCdI9oqh/rZ9lEoo3EHk/Lt6H2p/t6jyQf0sWqtsbJeHg5j5FzX6ZwYkdX8lTmBBMTrlyf9A==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.0.0-beta.55",
+        "@babel/types": "7.0.0-beta.56",
         "esutils": "^2.0.0"
       }
     },
     "@babel/helper-call-delegate": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.0.0-beta.55.tgz",
-      "integrity": "sha1-E/aMhcKt/ofAL3q00qY9Nc1n1yQ=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.0.0-beta.56.tgz",
+      "integrity": "sha512-XOv0taD7Elw0CSorktXbbCzdPgH4dZOb8yObk5deEhDbWgJhdwIvd5z8rQpDu712oqDhXm7Z3v+upFsOCg2+nQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-hoist-variables": "7.0.0-beta.55",
-        "@babel/traverse": "7.0.0-beta.55",
-        "@babel/types": "7.0.0-beta.55"
+        "@babel/helper-hoist-variables": "7.0.0-beta.56",
+        "@babel/traverse": "7.0.0-beta.56",
+        "@babel/types": "7.0.0-beta.56"
       }
     },
     "@babel/helper-define-map": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.0.0-beta.55.tgz",
-      "integrity": "sha1-tivLN7dTvkFtt/IVY/AWLNkzQDo=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.0.0-beta.56.tgz",
+      "integrity": "sha512-6hWVBpEyeRqvX3cKU7GVjdiYk9SvucpScTwdNpuSvsX8lX1MzuLQ7n9FNrHMU6+ulVNkZV81E7WdABYgXyIfuw==",
       "dev": true,
       "requires": {
-        "@babel/helper-function-name": "7.0.0-beta.55",
-        "@babel/types": "7.0.0-beta.55",
+        "@babel/helper-function-name": "7.0.0-beta.56",
+        "@babel/types": "7.0.0-beta.56",
         "lodash": "^4.17.10"
       }
     },
     "@babel/helper-explode-assignable-expression": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.0.0-beta.55.tgz",
-      "integrity": "sha1-9cCW8mHKTvxhVLJjMxfuwe2QKeo=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.0.0-beta.56.tgz",
+      "integrity": "sha512-Y3a7HLnwLJEiKe4+XB2AEo6QiCnFsa0ycqg6HBp0lyw4HztSTGt3oyZYO8I5ZhtVCKi/EJXSQuKHLOV98jG/+A==",
       "dev": true,
       "requires": {
-        "@babel/traverse": "7.0.0-beta.55",
-        "@babel/types": "7.0.0-beta.55"
+        "@babel/traverse": "7.0.0-beta.56",
+        "@babel/types": "7.0.0-beta.56"
       }
     },
     "@babel/helper-function-name": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.55.tgz",
-      "integrity": "sha1-FqqyE4Ci6rzuMyjSG5WGujQn2+8=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.56.tgz",
+      "integrity": "sha512-Lq4nPOt1j3sUq+1GVrw57dKq6wBKAHplGjYzEG8dkytqo93i6uSKKKg3smYXx2qohEVD5ciAyJjgRJq7RQu4Lg==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "7.0.0-beta.55",
-        "@babel/template": "7.0.0-beta.55",
-        "@babel/types": "7.0.0-beta.55"
+        "@babel/helper-get-function-arity": "7.0.0-beta.56",
+        "@babel/template": "7.0.0-beta.56",
+        "@babel/types": "7.0.0-beta.56"
       }
     },
     "@babel/helper-get-function-arity": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.55.tgz",
-      "integrity": "sha1-hVne2W7NO2JvnB9XSU7cT6PMapQ=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.56.tgz",
+      "integrity": "sha512-QU9EVlnDGTzBasgrdo/I4+RzZS7oqzz9YcetpYko3bp+VsRGokqsAQl3gIvxWTtxwibwboDEdBx+fGArtb2fhw==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.0.0-beta.55"
+        "@babel/types": "7.0.0-beta.56"
       }
     },
     "@babel/helper-hoist-variables": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0-beta.55.tgz",
-      "integrity": "sha1-qIxdmS3KEJGZz5WyWQdTSpWdxGE=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0-beta.56.tgz",
+      "integrity": "sha512-PTBa6UfiM7MgeTXOlNjCDiiqtOhqWraHM2GGsZg1M8VkuZRjP1Kag9JNmoppUlsZE5LY3NE+BjJuQ1/mLgcIug==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.0.0-beta.55"
+        "@babel/types": "7.0.0-beta.56"
       }
     },
     "@babel/helper-member-expression-to-functions": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0-beta.55.tgz",
-      "integrity": "sha1-gj0lS8m9AZpSn+Krf54dJocMXlA=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0-beta.56.tgz",
+      "integrity": "sha512-/TrmPCG1XIENakzenEyiNsbIBSTm10DNWyB/cyKwVljzA18gMivn9YxSMxVAuaC1KyTTmhkeUYibSMF7yF13xw==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.0.0-beta.55"
+        "@babel/types": "7.0.0-beta.56"
       }
     },
     "@babel/helper-module-imports": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0-beta.55.tgz",
-      "integrity": "sha1-k/knxmMdBom4u9GZHT+yqmPus/I=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0-beta.56.tgz",
+      "integrity": "sha512-iVWFscU+yIu6DIo5IWkMgVXd74/d3z/ZomwF/QJNGFwFP/lNA282rpjsky56fSxS7oT7wAlXoYoHVCOOaL7tbg==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.0.0-beta.55",
+        "@babel/types": "7.0.0-beta.56",
         "lodash": "^4.17.10"
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.0.0-beta.55.tgz",
-      "integrity": "sha1-K9EvDpGH5daVmf+nwR/po6Z7A9I=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.0.0-beta.56.tgz",
+      "integrity": "sha512-jC+blwjVeVx43WWOJHHXYBcHvYw0eHNgZUUXHKkDTLYc0zx8oev3LyciGFiWz29KgCS1K8YYd0t7z8fFXlCTog==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "7.0.0-beta.55",
-        "@babel/helper-simple-access": "7.0.0-beta.55",
-        "@babel/helper-split-export-declaration": "7.0.0-beta.55",
-        "@babel/template": "7.0.0-beta.55",
-        "@babel/types": "7.0.0-beta.55",
+        "@babel/helper-module-imports": "7.0.0-beta.56",
+        "@babel/helper-simple-access": "7.0.0-beta.56",
+        "@babel/helper-split-export-declaration": "7.0.0-beta.56",
+        "@babel/template": "7.0.0-beta.56",
+        "@babel/types": "7.0.0-beta.56",
         "lodash": "^4.17.10"
       }
     },
     "@babel/helper-optimise-call-expression": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0-beta.55.tgz",
-      "integrity": "sha1-V/3GiYvFPwLaeL9KOVCdTfw7M8s=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0-beta.56.tgz",
+      "integrity": "sha512-T+eZePA6kM+3wHXDPKKFZGHtMJGfK2/xmdk9pVjFHppdg4zwEqGaqLQaOlqfk5ekx2vxO22tmL4Caf2A/MVm0w==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.0.0-beta.55"
+        "@babel/types": "7.0.0-beta.56"
       }
     },
     "@babel/helper-plugin-utils": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.55.tgz",
-      "integrity": "sha1-MfQHd+/WuWHahJapI8ItKwYrP3M=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.56.tgz",
+      "integrity": "sha512-6IlFMU13X7gwnnMldDHwfc7IqngqCH/KfiU7I+GdNoZPnddmjghc87E/zKHaJpWdX1VvXCCelp2EnKq0rgBQ8w==",
       "dev": true
     },
     "@babel/helper-regex": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.0.0-beta.55.tgz",
-      "integrity": "sha1-dObAY9Hvn35Yt6hMBubuSlu1pdo=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.0.0-beta.56.tgz",
+      "integrity": "sha512-wtb8bmlc5TF7W7KMd5muS+CVQQu7cNGTdPbI5+8x5w36bN8ytbkun5160hJ2S1r3Tti0FPnrYwz+9W5AGj+d9g==",
       "dev": true,
       "requires": {
         "lodash": "^4.17.10"
       }
     },
     "@babel/helper-remap-async-to-generator": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.0.0-beta.55.tgz",
-      "integrity": "sha1-52LRuPfwYSHtPkC++x+YR9Rlin0=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.0.0-beta.56.tgz",
+      "integrity": "sha512-uCvdjXeEh/qzvhK61XLP5DADCM0MMxZOVdGIj5In/i9MLt9BD/EAyBmjZN0bc1dD1wJst0qInZyZju0lUUkvNQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "7.0.0-beta.55",
-        "@babel/helper-wrap-function": "7.0.0-beta.55",
-        "@babel/template": "7.0.0-beta.55",
-        "@babel/traverse": "7.0.0-beta.55",
-        "@babel/types": "7.0.0-beta.55"
+        "@babel/helper-annotate-as-pure": "7.0.0-beta.56",
+        "@babel/helper-wrap-function": "7.0.0-beta.56",
+        "@babel/template": "7.0.0-beta.56",
+        "@babel/traverse": "7.0.0-beta.56",
+        "@babel/types": "7.0.0-beta.56"
       }
     },
     "@babel/helper-replace-supers": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.0.0-beta.55.tgz",
-      "integrity": "sha1-1YithjmQ812LD2eqlO+O7CQXGFU=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.0.0-beta.56.tgz",
+      "integrity": "sha512-Pv0a8XYWeYLMgzx6BiKYMkBPW7ilDeKmKnPfMD+sCsTRDMZl9DssqnkkSwGxgAeuPwZ9opx18r5EzYPTgt0k4A==",
       "dev": true,
       "requires": {
-        "@babel/helper-member-expression-to-functions": "7.0.0-beta.55",
-        "@babel/helper-optimise-call-expression": "7.0.0-beta.55",
-        "@babel/traverse": "7.0.0-beta.55",
-        "@babel/types": "7.0.0-beta.55"
+        "@babel/helper-member-expression-to-functions": "7.0.0-beta.56",
+        "@babel/helper-optimise-call-expression": "7.0.0-beta.56",
+        "@babel/traverse": "7.0.0-beta.56",
+        "@babel/types": "7.0.0-beta.56"
       }
     },
     "@babel/helper-simple-access": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.0.0-beta.55.tgz",
-      "integrity": "sha1-8/POJ58g/JDBZsT+oWZ2RoV7pVk=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.0.0-beta.56.tgz",
+      "integrity": "sha512-CIRkGs+/KNWpGJKEUbABeVWTZ1ePskwKwwoR1lVs2qI4cZheS6NvXzLxsFN/uxyc46yn7px/XTxV/zM3rnlQQQ==",
       "dev": true,
       "requires": {
-        "@babel/template": "7.0.0-beta.55",
-        "@babel/types": "7.0.0-beta.55",
+        "@babel/template": "7.0.0-beta.56",
+        "@babel/types": "7.0.0-beta.56",
         "lodash": "^4.17.10"
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.55.tgz",
-      "integrity": "sha1-7LgHS/LSLGUYolIoJTXe8TeocE8=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.56.tgz",
+      "integrity": "sha512-j886mQJQg5HDF7X0qK/AfNdrpIYUcJHxRKwBJ9dUvhpO3eFqsTLbJJpitgLaJQjh9D7Db5Aiq8MRghj3+MH57g==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.0.0-beta.55"
+        "@babel/types": "7.0.0-beta.56"
       }
     },
     "@babel/helper-wrap-function": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.0.0-beta.55.tgz",
-      "integrity": "sha1-MFPndkcFeym4jZYlUD4DOxvTSbQ=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.0.0-beta.56.tgz",
+      "integrity": "sha512-WuGMzbpx12M40aHtocM0vs9af/LmdwpXsKBX2T2GqCMueD90MHvQU+148vHScgPbUoWP4lv+dFGZDf0XUc2qJA==",
       "dev": true,
       "requires": {
-        "@babel/helper-function-name": "7.0.0-beta.55",
-        "@babel/template": "7.0.0-beta.55",
-        "@babel/traverse": "7.0.0-beta.55",
-        "@babel/types": "7.0.0-beta.55"
+        "@babel/helper-function-name": "7.0.0-beta.56",
+        "@babel/template": "7.0.0-beta.56",
+        "@babel/traverse": "7.0.0-beta.56",
+        "@babel/types": "7.0.0-beta.56"
       }
     },
     "@babel/helpers": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.0.0-beta.55.tgz",
-      "integrity": "sha1-0LS5oyfbpC1YiQAR3rkFyCBzlhc=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.0.0-beta.56.tgz",
+      "integrity": "sha512-KaNBuVlAGW6sFCEWjliN29dL8K4L/ff8ZUaR/D5ou/JsqOuxLRy34Rf8WXMru3Et2g4Czly6vJeSmaYyf3s0lA==",
       "dev": true,
       "requires": {
-        "@babel/template": "7.0.0-beta.55",
-        "@babel/traverse": "7.0.0-beta.55",
-        "@babel/types": "7.0.0-beta.55"
+        "@babel/template": "7.0.0-beta.56",
+        "@babel/traverse": "7.0.0-beta.56",
+        "@babel/types": "7.0.0-beta.56"
       }
     },
     "@babel/highlight": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.55.tgz",
-      "integrity": "sha1-mIZTZH1inCYdrhVudNXwJSulIMA=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.56.tgz",
+      "integrity": "sha512-q4TfI+jJISul6vVpZJktzH4tupwRiVk6KXRhB8PHqJ7erl966I6ePDXl9mAbE8jMM7YswhnnB0j1SYP7LBVyhg==",
       "dev": true,
       "requires": {
         "chalk": "^2.0.0",
@@ -304,13 +304,13 @@
       }
     },
     "@babel/node": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/node/-/node-7.0.0-beta.55.tgz",
-      "integrity": "sha1-2GKTRR7aLSHPf0YHOGBQaFNAy3I=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/node/-/node-7.0.0-beta.56.tgz",
+      "integrity": "sha512-HT+JX6ZbyWRR11cN7WglLdKP6j4YXwuk/HK5MVsvsQkjo6MsqhRhXR0/UmWs8oHnraeLQCgQrtobXoyLv6RNiw==",
       "dev": true,
       "requires": {
-        "@babel/polyfill": "7.0.0-beta.55",
-        "@babel/register": "7.0.0-beta.55",
+        "@babel/polyfill": "7.0.0-beta.56",
+        "@babel/register": "7.0.0-beta.56",
         "commander": "^2.8.1",
         "fs-readdir-recursive": "^1.0.0",
         "lodash": "^4.17.10",
@@ -319,473 +319,473 @@
       }
     },
     "@babel/parser": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.55.tgz",
-      "integrity": "sha1-ClJ+/BSMbIzYXV/92srYF6La7rI=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.56.tgz",
+      "integrity": "sha512-JM0ughhbo+sPXw2Z+SUyowfYrAOhjanzjMshcLswBdXVelJCOeEKe/FqMqPWGVPQr7wByongXIn+MKdCpY7DBw==",
       "dev": true
     },
     "@babel/plugin-proposal-async-generator-functions": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.0.0-beta.55.tgz",
-      "integrity": "sha1-USuyjAQBdpgRgY1rRFPOm99fIco=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.0.0-beta.56.tgz",
+      "integrity": "sha512-2amegw5EfeOJO5un5+A5cZ7cELUKf7fUzdryFdkg3ciGyNA+ISK9x4B57N8Jb5gWXch1xNsOV7tJuaaWeqbJ3g==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.55",
-        "@babel/helper-remap-async-to-generator": "7.0.0-beta.55",
-        "@babel/plugin-syntax-async-generators": "7.0.0-beta.55"
+        "@babel/helper-plugin-utils": "7.0.0-beta.56",
+        "@babel/helper-remap-async-to-generator": "7.0.0-beta.56",
+        "@babel/plugin-syntax-async-generators": "7.0.0-beta.56"
       }
     },
     "@babel/plugin-proposal-class-properties": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.0.0-beta.55.tgz",
-      "integrity": "sha1-2QeStbQnnnCPfCowva1IncOYxX8=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.0.0-beta.56.tgz",
+      "integrity": "sha512-OMfd8vJp0lO8cc4RtdtkTJ7nXP0lZlSYLwuX8HPYwd1BIZ00e92z4xzcVGZZCF9BW+Rl9flM9OYwjmlZkcvxyA==",
       "dev": true,
       "requires": {
-        "@babel/helper-function-name": "7.0.0-beta.55",
-        "@babel/helper-member-expression-to-functions": "7.0.0-beta.55",
-        "@babel/helper-optimise-call-expression": "7.0.0-beta.55",
-        "@babel/helper-plugin-utils": "7.0.0-beta.55",
-        "@babel/helper-replace-supers": "7.0.0-beta.55",
-        "@babel/plugin-syntax-class-properties": "7.0.0-beta.55"
+        "@babel/helper-function-name": "7.0.0-beta.56",
+        "@babel/helper-member-expression-to-functions": "7.0.0-beta.56",
+        "@babel/helper-optimise-call-expression": "7.0.0-beta.56",
+        "@babel/helper-plugin-utils": "7.0.0-beta.56",
+        "@babel/helper-replace-supers": "7.0.0-beta.56",
+        "@babel/plugin-syntax-class-properties": "7.0.0-beta.56"
       }
     },
     "@babel/plugin-proposal-numeric-separator": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.0.0-beta.55.tgz",
-      "integrity": "sha1-RIPlLBXMLRvHrTG+SddRwEykKOE=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.0.0-beta.56.tgz",
+      "integrity": "sha512-zuSOULEsNDHsdFnN8/gEJqqBR6gw+WWs4zRamaZbY9PEx91HLNCz4Zs7AM6YafYs3sAwsk2mXpWyvjSViPCNmg==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.55",
-        "@babel/plugin-syntax-numeric-separator": "7.0.0-beta.55"
+        "@babel/helper-plugin-utils": "7.0.0-beta.56",
+        "@babel/plugin-syntax-numeric-separator": "7.0.0-beta.56"
       }
     },
     "@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0-beta.55.tgz",
-      "integrity": "sha1-thG7g5Ab8FGWI3xRaouxEXoqk5Y=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0-beta.56.tgz",
+      "integrity": "sha512-onVk2kI39dzkDP+SzX6eC3nAkq5yemiiZX+AuXAmshOyuz+ZYUu5b+zzXKw0oPFTSnMnlIfJItQCcVzesXcU6A==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.55",
-        "@babel/plugin-syntax-object-rest-spread": "7.0.0-beta.55"
+        "@babel/helper-plugin-utils": "7.0.0-beta.56",
+        "@babel/plugin-syntax-object-rest-spread": "7.0.0-beta.56"
       }
     },
     "@babel/plugin-proposal-optional-catch-binding": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.0.0-beta.55.tgz",
-      "integrity": "sha1-NlcnshSj4+XL65LEcWNaX1GDlzU=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.0.0-beta.56.tgz",
+      "integrity": "sha512-qLUAi1k8kTiFDUfGkjtdWujo6hTcqCDRw9hvBSxgJ150fRytyCG0pDqmC3KXytSdPPxuAcCCbgB+9CZsGPXkIA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.55",
-        "@babel/plugin-syntax-optional-catch-binding": "7.0.0-beta.55"
+        "@babel/helper-plugin-utils": "7.0.0-beta.56",
+        "@babel/plugin-syntax-optional-catch-binding": "7.0.0-beta.56"
       }
     },
     "@babel/plugin-proposal-throw-expressions": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-throw-expressions/-/plugin-proposal-throw-expressions-7.0.0-beta.55.tgz",
-      "integrity": "sha1-olY93PTbdOcyYHh75Wn+mIqBa5k=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-throw-expressions/-/plugin-proposal-throw-expressions-7.0.0-beta.56.tgz",
+      "integrity": "sha512-yB5gJOkbs3+uj1Yo468E+3bfWlHitj1Z7LwUsxi4p/AkEs7eJy6oTN3uilmjFpaimdfL6Sit5MzlXIT2/TvE7Q==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.55",
-        "@babel/plugin-syntax-throw-expressions": "7.0.0-beta.55"
+        "@babel/helper-plugin-utils": "7.0.0-beta.56",
+        "@babel/plugin-syntax-throw-expressions": "7.0.0-beta.56"
       }
     },
     "@babel/plugin-proposal-unicode-property-regex": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.0.0-beta.55.tgz",
-      "integrity": "sha1-mH+FHU9Q+7kcF7pRzBE9jT9VjFs=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.0.0-beta.56.tgz",
+      "integrity": "sha512-YszvYRt3tgCTJ+qcBSRKpJhlsiM0/BPcehwHgFzyKi0arnRX7jO8iyTZD3VpkVBElTGTbz91G9fSXj/7Y3PdQw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.55",
-        "@babel/helper-regex": "7.0.0-beta.55",
+        "@babel/helper-plugin-utils": "7.0.0-beta.56",
+        "@babel/helper-regex": "7.0.0-beta.56",
         "regexpu-core": "^4.2.0"
       }
     },
     "@babel/plugin-syntax-async-generators": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0-beta.55.tgz",
-      "integrity": "sha1-5ys4V+uAtpXHfDchI3sUkHLNpGs=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0-beta.56.tgz",
+      "integrity": "sha512-tC8sGd1RridRn0147GUh2rF1WB+8FnP0siTD0ofuqLYJEbOTYn9NF0WD4DNzwwHwOZMBxgHFy8N/B1sNmEC8SQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.55"
+        "@babel/helper-plugin-utils": "7.0.0-beta.56"
       }
     },
     "@babel/plugin-syntax-class-properties": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.0.0-beta.55.tgz",
-      "integrity": "sha1-7O+U+6mLXsuopJmRwKsw3mcj3JQ=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.0.0-beta.56.tgz",
+      "integrity": "sha512-7aq+tQjiOb6pNl5sFn1lSi6sM+LIWw4eRocFZKhbr1GX9hW9I8jV9G+lxvfswiKniyYRyeAua7yIz/VuCH/tfQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.55"
+        "@babel/helper-plugin-utils": "7.0.0-beta.56"
       }
     },
     "@babel/plugin-syntax-jsx": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.0.0-beta.55.tgz",
-      "integrity": "sha1-PBbMlysxwn1MLmOI6DTxRkYyY6Q=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.0.0-beta.56.tgz",
+      "integrity": "sha512-QsZbghj9DemNxr6ZX7V1ULukXrb+d3kRAU9ErikMnSCx60tKW5MQCIuSnHjr1l5wU4XlAZT2qclb+RYTTz0rAw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.55"
+        "@babel/helper-plugin-utils": "7.0.0-beta.56"
       }
     },
     "@babel/plugin-syntax-numeric-separator": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.0.0-beta.55.tgz",
-      "integrity": "sha1-C4KRAqPxhKTMvLRjR439jSE0Zlo=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.0.0-beta.56.tgz",
+      "integrity": "sha512-GsOEExTOdk7y6qC2E7Qm1IkAHlGVUBmE9KRBi802klDCPYu4AUIZBn6pHrIZ3KWZySOt21PpDowqkfmv4vW6DQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.55"
+        "@babel/helper-plugin-utils": "7.0.0-beta.56"
       }
     },
     "@babel/plugin-syntax-object-rest-spread": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.0.0-beta.55.tgz",
-      "integrity": "sha1-mQ6kfnkNfZqdKEaca8wV9YC/Gek=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.0.0-beta.56.tgz",
+      "integrity": "sha512-rDqe3TN5cZaUg4zi3Kzfq5qySS6IcEs19WE7GHlmelgQ1QXy9d/tsPEAWHZTLrG4mjbbEFJZdLvAi+LSGdhJAQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.55"
+        "@babel/helper-plugin-utils": "7.0.0-beta.56"
       }
     },
     "@babel/plugin-syntax-optional-catch-binding": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.0.0-beta.55.tgz",
-      "integrity": "sha1-75A/7i28NiF3PX2y3smGHI+XbBI=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.0.0-beta.56.tgz",
+      "integrity": "sha512-rpXmUoqQRwV3QaRUIwKTrVh/pzYe1mMmV43TXJNkP3BX4phimxsF+/orJY8MjqZs9QfHwQkfyb+b6BURLY62kA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.55"
+        "@babel/helper-plugin-utils": "7.0.0-beta.56"
       }
     },
     "@babel/plugin-syntax-throw-expressions": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-throw-expressions/-/plugin-syntax-throw-expressions-7.0.0-beta.55.tgz",
-      "integrity": "sha1-Mi7UGwY8IRXDX7bHtjcz5gAlo24=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-throw-expressions/-/plugin-syntax-throw-expressions-7.0.0-beta.56.tgz",
+      "integrity": "sha512-I407BTq74GCfQq/ys8frwT2RgwIO91dm6y8ddxrqNv4mHi0AXQ7r2NbHUXcqXdqEqTAg6M4TeqVchJXSV+lmxQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.55"
+        "@babel/helper-plugin-utils": "7.0.0-beta.56"
       }
     },
     "@babel/plugin-transform-arrow-functions": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.0.0-beta.55.tgz",
-      "integrity": "sha1-6stEb/xn5RNaSimscr/6wa2hgfY=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.0.0-beta.56.tgz",
+      "integrity": "sha512-TkpqdTt8ivvNBoawwxwFJSHRAQAWvWRuMyQIJfdrmSGdHVaEJ8xn1MkYuORMOogtpsG+ZncmGRAyCEQeMFBPsA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.55"
+        "@babel/helper-plugin-utils": "7.0.0-beta.56"
       }
     },
     "@babel/plugin-transform-async-to-generator": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.0.0-beta.55.tgz",
-      "integrity": "sha1-SQpHFVQIB72J9YWOiqww0VYb3WU=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.0.0-beta.56.tgz",
+      "integrity": "sha512-n34TSk3nFLCnsuC5f2PSb+jdOVXv1UzENnGN/Xu9/epSFVVNLfNR2td0Gx0Rh4CjIef5JZ0tFounyPWWMSh/0Q==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "7.0.0-beta.55",
-        "@babel/helper-plugin-utils": "7.0.0-beta.55",
-        "@babel/helper-remap-async-to-generator": "7.0.0-beta.55"
+        "@babel/helper-module-imports": "7.0.0-beta.56",
+        "@babel/helper-plugin-utils": "7.0.0-beta.56",
+        "@babel/helper-remap-async-to-generator": "7.0.0-beta.56"
       }
     },
     "@babel/plugin-transform-block-scoped-functions": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.0.0-beta.55.tgz",
-      "integrity": "sha1-BnDQoUlDXupz9y4zkqUbON5gcnA=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.0.0-beta.56.tgz",
+      "integrity": "sha512-rgabVaR9M5c7xyuWFMyPN8vT8QkncF9skgA2/O6seiGX8mgl/WjDMkWi2Sm9PFdPc7WEryKh8Rlu/tgupulwSA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.55"
+        "@babel/helper-plugin-utils": "7.0.0-beta.56"
       }
     },
     "@babel/plugin-transform-block-scoping": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.0.0-beta.55.tgz",
-      "integrity": "sha1-yCb4wgMErDn2zdEdFPHNfZCqVHA=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.0.0-beta.56.tgz",
+      "integrity": "sha512-hqeciuZPUfsZIhJ6MaB68U3+G5eS12ahidn98oUxyOl+BnS/aN9EhSt877mJPlEBe3oQy35qNwg/HG3rq33O2A==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.55",
+        "@babel/helper-plugin-utils": "7.0.0-beta.56",
         "lodash": "^4.17.10"
       }
     },
     "@babel/plugin-transform-classes": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.0.0-beta.55.tgz",
-      "integrity": "sha1-+iYCZpQ/eh4UTvl4PZoH6Yd1UCI=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.0.0-beta.56.tgz",
+      "integrity": "sha512-uq0Nvjlkt5gpF+dlvJ1yOZu8liBfOp3QoA/hrP7LZ6XzmYwZOhIUpUbouvKjgvybWiDmNDGcELeC96CL/mtV5Q==",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "7.0.0-beta.55",
-        "@babel/helper-define-map": "7.0.0-beta.55",
-        "@babel/helper-function-name": "7.0.0-beta.55",
-        "@babel/helper-optimise-call-expression": "7.0.0-beta.55",
-        "@babel/helper-plugin-utils": "7.0.0-beta.55",
-        "@babel/helper-replace-supers": "7.0.0-beta.55",
-        "@babel/helper-split-export-declaration": "7.0.0-beta.55",
+        "@babel/helper-annotate-as-pure": "7.0.0-beta.56",
+        "@babel/helper-define-map": "7.0.0-beta.56",
+        "@babel/helper-function-name": "7.0.0-beta.56",
+        "@babel/helper-optimise-call-expression": "7.0.0-beta.56",
+        "@babel/helper-plugin-utils": "7.0.0-beta.56",
+        "@babel/helper-replace-supers": "7.0.0-beta.56",
+        "@babel/helper-split-export-declaration": "7.0.0-beta.56",
         "globals": "^11.1.0"
       }
     },
     "@babel/plugin-transform-computed-properties": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.0.0-beta.55.tgz",
-      "integrity": "sha1-oE8QHzBWlQMf/aYVAXKMABgCN7k=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.0.0-beta.56.tgz",
+      "integrity": "sha512-U0iHc3aEhgJsW5toS4ZjwWp9bV1l+gsJAt4PI/fXA4XK0DVZEZS82Xq3ozHLp5ccWiqJCCEWYAFys2c/ZPKmjA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.55"
+        "@babel/helper-plugin-utils": "7.0.0-beta.56"
       }
     },
     "@babel/plugin-transform-destructuring": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.0.0-beta.55.tgz",
-      "integrity": "sha1-HUQhbLvbXYc4Gau3H+AzwUocFyM=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.0.0-beta.56.tgz",
+      "integrity": "sha512-6Jyis4rwPNQ9a8t1PerzymtC0qfgKlI9SOc44xaZfVo2nxzhb09nXrGsjpXywZVepDUWKHXy17XT0ouiQJmrTw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.55"
+        "@babel/helper-plugin-utils": "7.0.0-beta.56"
       }
     },
     "@babel/plugin-transform-dotall-regex": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.0.0-beta.55.tgz",
-      "integrity": "sha1-K5wtE7ebZgeJtA+fSYc1JdfXdDc=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.0.0-beta.56.tgz",
+      "integrity": "sha512-nM7ZXzwdDwviGUleCdDrQ4fGXtTkEFg0HHbZ5LD7XlJrN4goJmi6xHBOoZ8iWdTPrzAuDi+FT87RWCHFDcU4xA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.55",
-        "@babel/helper-regex": "7.0.0-beta.55",
+        "@babel/helper-plugin-utils": "7.0.0-beta.56",
+        "@babel/helper-regex": "7.0.0-beta.56",
         "regexpu-core": "^4.1.3"
       }
     },
     "@babel/plugin-transform-duplicate-keys": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.0.0-beta.55.tgz",
-      "integrity": "sha1-0TAMYHA9W1IF9l6heLe1cV0Lloc=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.0.0-beta.56.tgz",
+      "integrity": "sha512-hnMT8itOVeLuLGtuE+SBpaCyLj97nq2LJwu2Ud6O6Nag1iswDp2MMgTYmFPzPF465LuP4cUp5bmjZcOvFkkoHQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.55"
+        "@babel/helper-plugin-utils": "7.0.0-beta.56"
       }
     },
     "@babel/plugin-transform-exponentiation-operator": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.0.0-beta.55.tgz",
-      "integrity": "sha1-3crA6oDmZBaBpHOnAwk80vYjpZ4=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.0.0-beta.56.tgz",
+      "integrity": "sha512-t32wjgnTXwOMDd8cIUSpYu3k31EqrYTJsZf/Dw44RDT6EXJzeTKchMsvwd2n8vf02OzjO0a9/qXF5dKl4cK0HQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-builder-binary-assignment-operator-visitor": "7.0.0-beta.55",
-        "@babel/helper-plugin-utils": "7.0.0-beta.55"
+        "@babel/helper-builder-binary-assignment-operator-visitor": "7.0.0-beta.56",
+        "@babel/helper-plugin-utils": "7.0.0-beta.56"
       }
     },
     "@babel/plugin-transform-for-of": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.0.0-beta.55.tgz",
-      "integrity": "sha1-zzBYxtgaPWnl3whilGiNrCikJxA=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.0.0-beta.56.tgz",
+      "integrity": "sha512-z4sift6xY65vOpFlRyPrcKNgusCV9NZZGOR9Dxt64XUEWnyxpabHZ9mGe0B3mqJbm168cK7sbxruvnyfyrO2fg==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.55"
+        "@babel/helper-plugin-utils": "7.0.0-beta.56"
       }
     },
     "@babel/plugin-transform-function-name": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.0.0-beta.55.tgz",
-      "integrity": "sha1-EUOE1W4XOUkr1M6TN90Vis3hSAE=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.0.0-beta.56.tgz",
+      "integrity": "sha512-olcHC1WD2L36/vUl/aw5STpv/+O4C/mUGOytQ2NJn0VPKqeaYCBaEboz+4nnttlvTojaxWzBURTl675YvlPcWw==",
       "dev": true,
       "requires": {
-        "@babel/helper-function-name": "7.0.0-beta.55",
-        "@babel/helper-plugin-utils": "7.0.0-beta.55"
+        "@babel/helper-function-name": "7.0.0-beta.56",
+        "@babel/helper-plugin-utils": "7.0.0-beta.56"
       }
     },
     "@babel/plugin-transform-literals": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.0.0-beta.55.tgz",
-      "integrity": "sha1-i8ks0k5kGTAe84Z+Rme3eqY3ThE=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.0.0-beta.56.tgz",
+      "integrity": "sha512-uz7Hcui2qmf1fA8pl5CsLz8KjM3HuUbEws/59G9kaMOrSIMrGSfeN1zsthfFSJDpFQLwq5NZ0+lPIvuOwE61bA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.55"
+        "@babel/helper-plugin-utils": "7.0.0-beta.56"
       }
     },
     "@babel/plugin-transform-modules-amd": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.0.0-beta.55.tgz",
-      "integrity": "sha1-yLWbhNb0mHUSZnxvlBCvPd1WLhI=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.0.0-beta.56.tgz",
+      "integrity": "sha512-qbYJ9Xfi17D6GWzqs6AIKbT5oN5A4ONwxMzqkvr501ft0JognN4Hc5W5UAyCGdNgY/V6+Qdf1t8Opd+zTcS1FA==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-transforms": "7.0.0-beta.55",
-        "@babel/helper-plugin-utils": "7.0.0-beta.55"
+        "@babel/helper-module-transforms": "7.0.0-beta.56",
+        "@babel/helper-plugin-utils": "7.0.0-beta.56"
       }
     },
     "@babel/plugin-transform-modules-commonjs": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.0.0-beta.55.tgz",
-      "integrity": "sha1-dIr1A34op4aU33G+Lo0CxchLiq8=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.0.0-beta.56.tgz",
+      "integrity": "sha512-48juOe+HB048Km4l7ZzCKptRlfnYGAC5WwPJrDzldHQ8JFFmbrZPoDGPSlDK/3z9JRMldBHioVHvID5WTYPE9g==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-transforms": "7.0.0-beta.55",
-        "@babel/helper-plugin-utils": "7.0.0-beta.55",
-        "@babel/helper-simple-access": "7.0.0-beta.55"
+        "@babel/helper-module-transforms": "7.0.0-beta.56",
+        "@babel/helper-plugin-utils": "7.0.0-beta.56",
+        "@babel/helper-simple-access": "7.0.0-beta.56"
       }
     },
     "@babel/plugin-transform-modules-systemjs": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.0.0-beta.55.tgz",
-      "integrity": "sha1-njan1IyRN3gUhMVELaQmhzKJWU4=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.0.0-beta.56.tgz",
+      "integrity": "sha512-tr2KAI4jhBfZLkSIHU4vlS6I1RmFYfMxM49ese+iPryvj1aH7x1VSz2+DEA/Xr+gM4CTXpWk0Xf2r2u260lPEA==",
       "dev": true,
       "requires": {
-        "@babel/helper-hoist-variables": "7.0.0-beta.55",
-        "@babel/helper-plugin-utils": "7.0.0-beta.55"
+        "@babel/helper-hoist-variables": "7.0.0-beta.56",
+        "@babel/helper-plugin-utils": "7.0.0-beta.56"
       }
     },
     "@babel/plugin-transform-modules-umd": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.0.0-beta.55.tgz",
-      "integrity": "sha1-AoyW9k6JMTZXxtX1/wZg/Jn27go=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.0.0-beta.56.tgz",
+      "integrity": "sha512-0ItEhFLodomK7FH2FgK+UAphXd95UKyj3SXcRRhbUifvpfnqv0QFgaffI01iEyFnbxdXKpZqESHZR1fV/w1igw==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-transforms": "7.0.0-beta.55",
-        "@babel/helper-plugin-utils": "7.0.0-beta.55"
+        "@babel/helper-module-transforms": "7.0.0-beta.56",
+        "@babel/helper-plugin-utils": "7.0.0-beta.56"
       }
     },
     "@babel/plugin-transform-new-target": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.0.0-beta.55.tgz",
-      "integrity": "sha1-AWStdYto9n/Dnb7xt9YeN/Wpv9U=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.0.0-beta.56.tgz",
+      "integrity": "sha512-8r4H92o1LX6xZ3gGCUwrIiMwEoOfUfbflKOzrNQig2ybhX+9thU63m0P7cIU4qgp60mzIDKj2m7bz17s6MCl5g==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.55"
+        "@babel/helper-plugin-utils": "7.0.0-beta.56"
       }
     },
     "@babel/plugin-transform-object-super": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.0.0-beta.55.tgz",
-      "integrity": "sha1-tRjROpA1ISgZFRTX1duOWnjJmSs=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.0.0-beta.56.tgz",
+      "integrity": "sha512-GB6OyxC16aIPE7lm13xfUsoP+zoqCn9PaocXzlGbQbotMoQ+qkmv3Ymq/Oy5YQl3kl5xrxX0JKNuOhYUjhG4YQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.55",
-        "@babel/helper-replace-supers": "7.0.0-beta.55"
+        "@babel/helper-plugin-utils": "7.0.0-beta.56",
+        "@babel/helper-replace-supers": "7.0.0-beta.56"
       }
     },
     "@babel/plugin-transform-parameters": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.0.0-beta.55.tgz",
-      "integrity": "sha1-8hHxilYKTZKNlknaEcKN2J8V7/4=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.0.0-beta.56.tgz",
+      "integrity": "sha512-zhGeuH/eY3kDVfFCWpyc1pWoIyuTZghqazsqJkUKwJMHoqVZuwEvNmpPi9Hhbn+W+LOFt8MJv5dY+kgfbMlwAQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-call-delegate": "7.0.0-beta.55",
-        "@babel/helper-get-function-arity": "7.0.0-beta.55",
-        "@babel/helper-plugin-utils": "7.0.0-beta.55"
+        "@babel/helper-call-delegate": "7.0.0-beta.56",
+        "@babel/helper-get-function-arity": "7.0.0-beta.56",
+        "@babel/helper-plugin-utils": "7.0.0-beta.56"
       }
     },
     "@babel/plugin-transform-react-display-name": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.0.0-beta.55.tgz",
-      "integrity": "sha1-2nIH8yPK3WjSYUtZL706TsaOj3U=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.0.0-beta.56.tgz",
+      "integrity": "sha512-K+MkaS/epgMstmKlUFsm1QxBHm+BTwI5TS5bgHh3M8N9ip4IQKAZacAAmQ6lNioIiO7TjH84qSZtBX+FYCgvtA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.55"
+        "@babel/helper-plugin-utils": "7.0.0-beta.56"
       }
     },
     "@babel/plugin-transform-react-jsx": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.0.0-beta.55.tgz",
-      "integrity": "sha1-ICuMgMLrHOYL8fM+ETr1XZ+5rVo=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.0.0-beta.56.tgz",
+      "integrity": "sha512-xg1l6yyWxxE4NdCIs+d3xx9Q03BmktxI9fIfxKaT0y+UjABg6J1eGCJRBPa1s3X212gkUcEmYPjG6jo4ew40Sw==",
       "dev": true,
       "requires": {
-        "@babel/helper-builder-react-jsx": "7.0.0-beta.55",
-        "@babel/helper-plugin-utils": "7.0.0-beta.55",
-        "@babel/plugin-syntax-jsx": "7.0.0-beta.55"
+        "@babel/helper-builder-react-jsx": "7.0.0-beta.56",
+        "@babel/helper-plugin-utils": "7.0.0-beta.56",
+        "@babel/plugin-syntax-jsx": "7.0.0-beta.56"
       }
     },
     "@babel/plugin-transform-react-jsx-self": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.0.0-beta.55.tgz",
-      "integrity": "sha1-gxOPgvUcTcw9debL5Ar2mrMCuAY=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.0.0-beta.56.tgz",
+      "integrity": "sha512-drNQEnMMaHaY1jANaMQVO0wRP2yf0nVstf6QHECzlCuOUaXvT7KtTgePv4fcpv2z/WSZCwQTM7ryHpeYobmNNQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.55",
-        "@babel/plugin-syntax-jsx": "7.0.0-beta.55"
+        "@babel/helper-plugin-utils": "7.0.0-beta.56",
+        "@babel/plugin-syntax-jsx": "7.0.0-beta.56"
       }
     },
     "@babel/plugin-transform-react-jsx-source": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.0.0-beta.55.tgz",
-      "integrity": "sha1-SRVvvoqIRrUYiLi4v/pIathIa3A=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.0.0-beta.56.tgz",
+      "integrity": "sha512-HQs16FPkc7B+XjvXLHVX95ouz55AiNPStUgAngeHOjNVq7veZ7CtYP2uzdXWUrl5JsglFeZj8wa3+zUALhhgJA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.55",
-        "@babel/plugin-syntax-jsx": "7.0.0-beta.55"
+        "@babel/helper-plugin-utils": "7.0.0-beta.56",
+        "@babel/plugin-syntax-jsx": "7.0.0-beta.56"
       }
     },
     "@babel/plugin-transform-regenerator": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0-beta.55.tgz",
-      "integrity": "sha1-oSuhN2xkfPC3d96op7Vf5GZe0f8=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0-beta.56.tgz",
+      "integrity": "sha512-wSRlSwXSXlpAdAKethZu+JyrnSL1NvLn3VtomlOCqHWhRhjOkjehIBlAe/AmguSn9JTUja0vqBWn1FS8sSnp7Q==",
       "dev": true,
       "requires": {
         "regenerator-transform": "^0.13.3"
       }
     },
     "@babel/plugin-transform-runtime": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.0.0-beta.55.tgz",
-      "integrity": "sha1-+btfq5NyJ10qEMHhJh9OmRAMfb4=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.0.0-beta.56.tgz",
+      "integrity": "sha512-bzIp/hDJwvN0hiVMlkiwC43N74R49nO+syW2wql8L48Md2z9nfsS0zw3T96oCDBUgGXzOX8uKq9DUKZS9YktTA==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "7.0.0-beta.55",
-        "@babel/helper-plugin-utils": "7.0.0-beta.55"
+        "@babel/helper-module-imports": "7.0.0-beta.56",
+        "@babel/helper-plugin-utils": "7.0.0-beta.56"
       }
     },
     "@babel/plugin-transform-shorthand-properties": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.0.0-beta.55.tgz",
-      "integrity": "sha1-del1dbh8b+McAI/D11X93NbLkIo=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.0.0-beta.56.tgz",
+      "integrity": "sha512-qfN9LTjglikI4N2K/WkZAJQijWQpsQefsC/sXEN6c4/G9n5ZJFyXt23aXXcjibncKbcTrRpmH0nTeMiZK0A+5A==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.55"
+        "@babel/helper-plugin-utils": "7.0.0-beta.56"
       }
     },
     "@babel/plugin-transform-spread": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.0.0-beta.55.tgz",
-      "integrity": "sha1-1aHDIKrIZGnW0xHhNqiftaH2VgA=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.0.0-beta.56.tgz",
+      "integrity": "sha512-C0EUKGVSU5ttbRe+ATn54oR2jdGzGIA8Uo/0jwtMeTU+6lewpTX8nu+M36JZDIcq2sSu7zxfLiRkErb/PX/Q0g==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.55"
+        "@babel/helper-plugin-utils": "7.0.0-beta.56"
       }
     },
     "@babel/plugin-transform-sticky-regex": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.0.0-beta.55.tgz",
-      "integrity": "sha1-0LgLLeuLTbA7xkWevnmtizm0BUY=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.0.0-beta.56.tgz",
+      "integrity": "sha512-VGPxbfefemuJg6/UVXf8WaaU9gIZRr31aLBsjDdYfj41N3W55LSvU+6CxCZ/ID6SfNCcQUEyBtZsWMWvv38Dhw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.55",
-        "@babel/helper-regex": "7.0.0-beta.55"
+        "@babel/helper-plugin-utils": "7.0.0-beta.56",
+        "@babel/helper-regex": "7.0.0-beta.56"
       }
     },
     "@babel/plugin-transform-template-literals": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.0.0-beta.55.tgz",
-      "integrity": "sha1-sApkltTIOEUHVZWYqvSdjBrYkuY=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.0.0-beta.56.tgz",
+      "integrity": "sha512-VMK/94Mlz24KFg0wc4Y4fAM6FNnx0wnr4A36rMdU54SYM3AEYzQcXtbI4uOCUSGdTOKR5zOiwhNnZFRodi29iA==",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "7.0.0-beta.55",
-        "@babel/helper-plugin-utils": "7.0.0-beta.55"
+        "@babel/helper-annotate-as-pure": "7.0.0-beta.56",
+        "@babel/helper-plugin-utils": "7.0.0-beta.56"
       }
     },
     "@babel/plugin-transform-typeof-symbol": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.0.0-beta.55.tgz",
-      "integrity": "sha1-YjJpGFYLdlu+nzYq06TOO8cUd7w=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.0.0-beta.56.tgz",
+      "integrity": "sha512-BnKyH+AUvnVHyl+1Kt40jfr6+0/DUED9huSdirp1DrKwmjlcu4FliGDNcSSKBfawV4covKT7MBjWpE6s+XNk1g==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.55"
+        "@babel/helper-plugin-utils": "7.0.0-beta.56"
       }
     },
     "@babel/plugin-transform-unicode-regex": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.0.0-beta.55.tgz",
-      "integrity": "sha1-h+e+27oQP3hKeZn4IGT0fAs1x5Y=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.0.0-beta.56.tgz",
+      "integrity": "sha512-31lEbd5voBJR8ufUuOaRu/r2dxj53S/fs+VNgPqCqvOw7Ql8AuuinYvJjxbzpZ5GqAWLPX1MKBgJ+gsjomXb6g==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.55",
-        "@babel/helper-regex": "7.0.0-beta.55",
+        "@babel/helper-plugin-utils": "7.0.0-beta.56",
+        "@babel/helper-regex": "7.0.0-beta.56",
         "regexpu-core": "^4.1.3"
       }
     },
     "@babel/polyfill": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.0.0-beta.55.tgz",
-      "integrity": "sha1-/GgVmjoy9n1AAymO5p00EmIrUwM=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.0.0-beta.56.tgz",
+      "integrity": "sha512-iuaguU+Gd0EVisIbGBGDAToG9TQRu1NHuNudiqQEqO2flNhFQ69MKUAVTGGssNwpfL1G5Vvk885/o4NfFPYgmg==",
       "dev": true,
       "requires": {
         "core-js": "^2.5.7",
@@ -793,47 +793,47 @@
       }
     },
     "@babel/preset-env": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.0.0-beta.55.tgz",
-      "integrity": "sha1-09mXUXdhiQFECB1TwMZpun6DNOA=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.0.0-beta.56.tgz",
+      "integrity": "sha512-kFjCCUuMr0Y0N1je1QtOd37WXCU3cEnAqjm4GRlbgWlBPcj7A7ZQ40jMfrPeqVUJBbFiqi/UbOK5iLP/K8wdsA==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "7.0.0-beta.55",
-        "@babel/helper-plugin-utils": "7.0.0-beta.55",
-        "@babel/plugin-proposal-async-generator-functions": "7.0.0-beta.55",
-        "@babel/plugin-proposal-object-rest-spread": "7.0.0-beta.55",
-        "@babel/plugin-proposal-optional-catch-binding": "7.0.0-beta.55",
-        "@babel/plugin-proposal-unicode-property-regex": "7.0.0-beta.55",
-        "@babel/plugin-syntax-async-generators": "7.0.0-beta.55",
-        "@babel/plugin-syntax-object-rest-spread": "7.0.0-beta.55",
-        "@babel/plugin-syntax-optional-catch-binding": "7.0.0-beta.55",
-        "@babel/plugin-transform-arrow-functions": "7.0.0-beta.55",
-        "@babel/plugin-transform-async-to-generator": "7.0.0-beta.55",
-        "@babel/plugin-transform-block-scoped-functions": "7.0.0-beta.55",
-        "@babel/plugin-transform-block-scoping": "7.0.0-beta.55",
-        "@babel/plugin-transform-classes": "7.0.0-beta.55",
-        "@babel/plugin-transform-computed-properties": "7.0.0-beta.55",
-        "@babel/plugin-transform-destructuring": "7.0.0-beta.55",
-        "@babel/plugin-transform-dotall-regex": "7.0.0-beta.55",
-        "@babel/plugin-transform-duplicate-keys": "7.0.0-beta.55",
-        "@babel/plugin-transform-exponentiation-operator": "7.0.0-beta.55",
-        "@babel/plugin-transform-for-of": "7.0.0-beta.55",
-        "@babel/plugin-transform-function-name": "7.0.0-beta.55",
-        "@babel/plugin-transform-literals": "7.0.0-beta.55",
-        "@babel/plugin-transform-modules-amd": "7.0.0-beta.55",
-        "@babel/plugin-transform-modules-commonjs": "7.0.0-beta.55",
-        "@babel/plugin-transform-modules-systemjs": "7.0.0-beta.55",
-        "@babel/plugin-transform-modules-umd": "7.0.0-beta.55",
-        "@babel/plugin-transform-new-target": "7.0.0-beta.55",
-        "@babel/plugin-transform-object-super": "7.0.0-beta.55",
-        "@babel/plugin-transform-parameters": "7.0.0-beta.55",
-        "@babel/plugin-transform-regenerator": "7.0.0-beta.55",
-        "@babel/plugin-transform-shorthand-properties": "7.0.0-beta.55",
-        "@babel/plugin-transform-spread": "7.0.0-beta.55",
-        "@babel/plugin-transform-sticky-regex": "7.0.0-beta.55",
-        "@babel/plugin-transform-template-literals": "7.0.0-beta.55",
-        "@babel/plugin-transform-typeof-symbol": "7.0.0-beta.55",
-        "@babel/plugin-transform-unicode-regex": "7.0.0-beta.55",
+        "@babel/helper-module-imports": "7.0.0-beta.56",
+        "@babel/helper-plugin-utils": "7.0.0-beta.56",
+        "@babel/plugin-proposal-async-generator-functions": "7.0.0-beta.56",
+        "@babel/plugin-proposal-object-rest-spread": "7.0.0-beta.56",
+        "@babel/plugin-proposal-optional-catch-binding": "7.0.0-beta.56",
+        "@babel/plugin-proposal-unicode-property-regex": "7.0.0-beta.56",
+        "@babel/plugin-syntax-async-generators": "7.0.0-beta.56",
+        "@babel/plugin-syntax-object-rest-spread": "7.0.0-beta.56",
+        "@babel/plugin-syntax-optional-catch-binding": "7.0.0-beta.56",
+        "@babel/plugin-transform-arrow-functions": "7.0.0-beta.56",
+        "@babel/plugin-transform-async-to-generator": "7.0.0-beta.56",
+        "@babel/plugin-transform-block-scoped-functions": "7.0.0-beta.56",
+        "@babel/plugin-transform-block-scoping": "7.0.0-beta.56",
+        "@babel/plugin-transform-classes": "7.0.0-beta.56",
+        "@babel/plugin-transform-computed-properties": "7.0.0-beta.56",
+        "@babel/plugin-transform-destructuring": "7.0.0-beta.56",
+        "@babel/plugin-transform-dotall-regex": "7.0.0-beta.56",
+        "@babel/plugin-transform-duplicate-keys": "7.0.0-beta.56",
+        "@babel/plugin-transform-exponentiation-operator": "7.0.0-beta.56",
+        "@babel/plugin-transform-for-of": "7.0.0-beta.56",
+        "@babel/plugin-transform-function-name": "7.0.0-beta.56",
+        "@babel/plugin-transform-literals": "7.0.0-beta.56",
+        "@babel/plugin-transform-modules-amd": "7.0.0-beta.56",
+        "@babel/plugin-transform-modules-commonjs": "7.0.0-beta.56",
+        "@babel/plugin-transform-modules-systemjs": "7.0.0-beta.56",
+        "@babel/plugin-transform-modules-umd": "7.0.0-beta.56",
+        "@babel/plugin-transform-new-target": "7.0.0-beta.56",
+        "@babel/plugin-transform-object-super": "7.0.0-beta.56",
+        "@babel/plugin-transform-parameters": "7.0.0-beta.56",
+        "@babel/plugin-transform-regenerator": "7.0.0-beta.56",
+        "@babel/plugin-transform-shorthand-properties": "7.0.0-beta.56",
+        "@babel/plugin-transform-spread": "7.0.0-beta.56",
+        "@babel/plugin-transform-sticky-regex": "7.0.0-beta.56",
+        "@babel/plugin-transform-template-literals": "7.0.0-beta.56",
+        "@babel/plugin-transform-typeof-symbol": "7.0.0-beta.56",
+        "@babel/plugin-transform-unicode-regex": "7.0.0-beta.56",
         "browserslist": "^3.0.0",
         "invariant": "^2.2.2",
         "js-levenshtein": "^1.1.3",
@@ -841,22 +841,22 @@
       }
     },
     "@babel/preset-react": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.0.0-beta.55.tgz",
-      "integrity": "sha1-gHeAZIgoUry8gS7LZ3NrSoGi/mw=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.0.0-beta.56.tgz",
+      "integrity": "sha512-xWj8x03hp8ZDghjlA81Yodx8EF6yjOgqFH5HVJmUAj7jjF1PrsNNCjACcz7mOBtKsOsv95jtKz/Rc3CcLeHqgw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.55",
-        "@babel/plugin-transform-react-display-name": "7.0.0-beta.55",
-        "@babel/plugin-transform-react-jsx": "7.0.0-beta.55",
-        "@babel/plugin-transform-react-jsx-self": "7.0.0-beta.55",
-        "@babel/plugin-transform-react-jsx-source": "7.0.0-beta.55"
+        "@babel/helper-plugin-utils": "7.0.0-beta.56",
+        "@babel/plugin-transform-react-display-name": "7.0.0-beta.56",
+        "@babel/plugin-transform-react-jsx": "7.0.0-beta.56",
+        "@babel/plugin-transform-react-jsx-self": "7.0.0-beta.56",
+        "@babel/plugin-transform-react-jsx-source": "7.0.0-beta.56"
       }
     },
     "@babel/register": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.0.0-beta.55.tgz",
-      "integrity": "sha1-kwv1oT+Z7rIsJ2s0alRYarsB5hE=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.0.0-beta.56.tgz",
+      "integrity": "sha512-QnCpfPKYQ/RCbD8hNYOugbdI+pBVZgRNcq012jB9fbu2Ca/H2xinFF2ycMWCkEKDNfmo/FqVfezivtb4VILeNA==",
       "dev": true,
       "requires": {
         "core-js": "^2.5.7",
@@ -869,47 +869,46 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0-beta.55.tgz",
-      "integrity": "sha1-C8M6paasCwEvN+JbnmqqLkiakWs=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0-beta.56.tgz",
+      "integrity": "sha512-vP9XV2VP013UEyZdU9eWClCsm6rQPUYHVNCfmpcv5uKviW7mKmUZq71Y5cr5dYsFKfnGDxSo8h6plUGR60lwHg==",
       "dev": true,
       "requires": {
-        "core-js": "^2.5.7",
         "regenerator-runtime": "^0.12.0"
       },
       "dependencies": {
         "regenerator-runtime": {
-          "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.0.tgz",
-          "integrity": "sha512-SpV2LhF5Dm9UYMEprB3WwsBnWwqTrmjrm2UZb42cl2G02WVGgx7Mg8aa9pdLEKp6hZ+/abcMc2NxKA8f02EG2w==",
+          "version": "0.12.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+          "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==",
           "dev": true
         }
       }
     },
     "@babel/template": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.55.tgz",
-      "integrity": "sha1-xsqw4nIrpeM/4DQHO20xZzq6Mm4=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.56.tgz",
+      "integrity": "sha512-rsR9K18h0oiJTUmS/ICYREbV8qhPTic4SIqDSkzv9xOxupt7dKj8hWmZQLGPySO5x6cdn8py039o1wPQnsEGHg==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.0.0-beta.55",
-        "@babel/parser": "7.0.0-beta.55",
-        "@babel/types": "7.0.0-beta.55",
+        "@babel/code-frame": "7.0.0-beta.56",
+        "@babel/parser": "7.0.0-beta.56",
+        "@babel/types": "7.0.0-beta.56",
         "lodash": "^4.17.10"
       }
     },
     "@babel/traverse": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.55.tgz",
-      "integrity": "sha1-UL5dD8xcxKwCCnsMUZvo2uNF1L4=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.56.tgz",
+      "integrity": "sha512-9WTqtKP2Ll+jG68r+JEecXAbdH/kk5inN1VDSDaTgdYtZ82BYUS9XRWMVpc5HB9LJsu2ZEyUA1cGybID7eeOXA==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.0.0-beta.55",
-        "@babel/generator": "7.0.0-beta.55",
-        "@babel/helper-function-name": "7.0.0-beta.55",
-        "@babel/helper-split-export-declaration": "7.0.0-beta.55",
-        "@babel/parser": "7.0.0-beta.55",
-        "@babel/types": "7.0.0-beta.55",
+        "@babel/code-frame": "7.0.0-beta.56",
+        "@babel/generator": "7.0.0-beta.56",
+        "@babel/helper-function-name": "7.0.0-beta.56",
+        "@babel/helper-split-export-declaration": "7.0.0-beta.56",
+        "@babel/parser": "7.0.0-beta.56",
+        "@babel/types": "7.0.0-beta.56",
         "debug": "^3.1.0",
         "globals": "^11.1.0",
         "lodash": "^4.17.10"
@@ -927,9 +926,9 @@
       }
     },
     "@babel/types": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.55.tgz",
-      "integrity": "sha1-d1XJ0uWDFaZPBdjPMyI3m+FtkZk=",
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.56.tgz",
+      "integrity": "sha512-fRIBeHtKxAD3D1E7hYSpG4MnLt0AfzHHs5gfVclOB0NlfLu3qiWU/IqdbK2ixTK61424iEkV1P/VAzndx6ungA==",
       "dev": true,
       "requires": {
         "esutils": "^2.0.2",
@@ -1240,9 +1239,9 @@
       "dev": true
     },
     "aws4": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
-      "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
       "dev": true
     },
     "babel-code-frame": {
@@ -1886,9 +1885,9 @@
       "optional": true
     },
     "caniuse-lite": {
-      "version": "1.0.30000872",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000872.tgz",
-      "integrity": "sha512-JcuiZ3a/2X5vAQQzR/BBTv1DDy964X4A+ecG2ocdMh1Lx6bcUBufYrqFlNgd1F/eAqUXHpNgiIj/B2kXl1ZtWQ==",
+      "version": "1.0.30000874",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000874.tgz",
+      "integrity": "sha512-29nr1EPiHwrJTAHHsEmTt2h+55L8j2GNFdAcYPlRy2NX6iFz7ZZiepVI7kP/QqlnHLq3KvfWpbmGa0d063U09w==",
       "dev": true
     },
     "canvas-prebuilt": {
@@ -1900,38 +1899,6 @@
         "node-pre-gyp": "^0.6.29",
         "parse-css-font": "^2.0.2",
         "units-css": "^0.4.0"
-      },
-      "dependencies": {
-        "node-pre-gyp": {
-          "version": "0.6.39",
-          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz",
-          "integrity": "sha512-OsJV74qxnvz/AMGgcfZoDaeDXKD3oY3QVIbBmwszTFkRisTSXbMQyn4UWzUMOtA5SVhrBZOTp0wcoSBgfMfMmQ==",
-          "dev": true,
-          "requires": {
-            "detect-libc": "^1.0.2",
-            "hawk": "3.1.3",
-            "mkdirp": "^0.5.1",
-            "nopt": "^4.0.1",
-            "npmlog": "^4.0.2",
-            "rc": "^1.1.7",
-            "request": "2.81.0",
-            "rimraf": "^2.6.1",
-            "semver": "^5.3.0",
-            "tar": "^2.2.1",
-            "tar-pack": "^3.4.0"
-          }
-        },
-        "tar": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-          "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-          "dev": true,
-          "requires": {
-            "block-stream": "*",
-            "fstream": "^1.0.2",
-            "inherits": "2"
-          }
-        }
       }
     },
     "capture-exit": {
@@ -2028,12 +1995,6 @@
         "readdirp": "^2.0.0",
         "upath": "^1.0.5"
       }
-    },
-    "chownr": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
-      "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
-      "dev": true
     },
     "ci-info": {
       "version": "1.1.3",
@@ -2159,9 +2120,9 @@
       }
     },
     "commander": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.16.0.tgz",
-      "integrity": "sha512-sVXqklSaotK9at437sFlFpyOcJonxe0yST/AG9DkQKUdIE6IqGIMv4SfAQSKaJbSdVEJYItASCrBiVQHq1HQew==",
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.0.tgz",
+      "integrity": "sha512-477o1hdVORiFlZxw8wgsXYCef3lh0zl/OV0FTftqiDxJSWw6dPQ2ipS4k20J2qBcsmsmLKSyr2iFrf9e3JGi4w==",
       "dev": true
     },
     "commondir": {
@@ -2629,9 +2590,9 @@
       }
     },
     "eslint": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.2.0.tgz",
-      "integrity": "sha512-zlggW1qp7/TBjwLfouRoY7eWXrXwJZFqCdIxxh0/LVB/QuuKuIMkzyUZEcDo6LBadsry5JcEMxIqd3H/66CXVg==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.3.0.tgz",
+      "integrity": "sha512-N/tCqlMKkyNvAvLu+zI9AqDasnSLt00K+Hu8kdsERliC9jYEc8ck12XtjvOXrBKu8fK6RrBcN9bat6Xk++9jAg==",
       "dev": true,
       "requires": {
         "ajv": "^6.5.0",
@@ -2665,7 +2626,7 @@
         "path-is-inside": "^1.0.2",
         "pluralize": "^7.0.0",
         "progress": "^2.0.0",
-        "regexpp": "^1.1.0",
+        "regexpp": "^2.0.0",
         "require-uncached": "^1.0.3",
         "semver": "^5.5.0",
         "string.prototype.matchall": "^2.0.0",
@@ -3298,15 +3259,6 @@
       "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
       "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
       "dev": true
-    },
-    "fs-minipass": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
-      "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
-      "dev": true,
-      "requires": {
-        "minipass": "^2.2.1"
-      }
     },
     "fs-readdir-recursive": {
       "version": "1.1.0",
@@ -4239,15 +4191,6 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.3.tgz",
       "integrity": "sha512-Z/vAH2GGIEATQnBVXMclE2IGV6i0GyVngKThcGZ5kHgHMxLo9Ow2+XHRq1aEKEej5vOF1TPJNbvX6J/anT0M7A==",
       "dev": true
-    },
-    "ignore-walk": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
-      "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
-      "dev": true,
-      "requires": {
-        "minimatch": "^3.0.4"
-      }
     },
     "import-local": {
       "version": "1.0.0",
@@ -6293,33 +6236,6 @@
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
     },
-    "minipass": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.3.tgz",
-      "integrity": "sha512-/jAn9/tEX4gnpyRATxgHEOV6xbcyxgT7iUnxo9Y3+OB0zX00TgKIv/2FZCf5brBbICcwbLqVv2ImjvWWrQMSYw==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "^5.1.2",
-        "yallist": "^3.0.0"
-      },
-      "dependencies": {
-        "yallist": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
-          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-          "dev": true
-        }
-      }
-    },
-    "minizlib": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
-      "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
-      "dev": true,
-      "requires": {
-        "minipass": "^2.2.1"
-      }
-    },
     "mixin-deep": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
@@ -6394,17 +6310,6 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
-    "needle": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.1.tgz",
-      "integrity": "sha512-t/ZswCM9JTWjAdXS9VpvqhI2Ct2sL2MdY4fUXqGJaGBk13ge99ObqRksRTbBE56K+wxUXwwfZYOuZHifFW9q+Q==",
-      "dev": true,
-      "requires": {
-        "debug": "^2.1.2",
-        "iconv-lite": "^0.4.4",
-        "sax": "^1.2.4"
-      }
-    },
     "nice-try": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.4.tgz",
@@ -6446,21 +6351,22 @@
       }
     },
     "node-pre-gyp": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.10.3.tgz",
-      "integrity": "sha512-d1xFs+C/IPS8Id0qPTZ4bUT8wWryfR/OzzAFxweG+uLN85oPzyo2Iw6bVlLQ/JOdgNonXLCoRyqDzDWq4iw72A==",
+      "version": "0.6.39",
+      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz",
+      "integrity": "sha512-OsJV74qxnvz/AMGgcfZoDaeDXKD3oY3QVIbBmwszTFkRisTSXbMQyn4UWzUMOtA5SVhrBZOTp0wcoSBgfMfMmQ==",
       "dev": true,
       "requires": {
         "detect-libc": "^1.0.2",
+        "hawk": "3.1.3",
         "mkdirp": "^0.5.1",
-        "needle": "^2.2.1",
         "nopt": "^4.0.1",
-        "npm-packlist": "^1.1.6",
         "npmlog": "^4.0.2",
-        "rc": "^1.2.7",
+        "rc": "^1.1.7",
+        "request": "2.81.0",
         "rimraf": "^2.6.1",
         "semver": "^5.3.0",
-        "tar": "^4"
+        "tar": "^2.2.1",
+        "tar-pack": "^3.4.0"
       }
     },
     "nopt": {
@@ -6492,22 +6398,6 @@
       "dev": true,
       "requires": {
         "remove-trailing-separator": "^1.0.1"
-      }
-    },
-    "npm-bundled": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.3.tgz",
-      "integrity": "sha512-ByQ3oJ/5ETLyglU2+8dBObvhfWXX8dtPZDMePCahptliFX2iIuhyEszyFk401PZUNQH20vvdW5MLjJxkwU80Ow==",
-      "dev": true
-    },
-    "npm-packlist": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.1.11.tgz",
-      "integrity": "sha512-CxKlZ24urLkJk+9kCm48RTQ7L4hsmgSVzEk0TLGPzzyuFxD7VNgy5Sl24tOLMzQv773a/NeJ1ce1DKeacqffEA==",
-      "dev": true,
-      "requires": {
-        "ignore-walk": "^3.0.1",
-        "npm-bundled": "^1.0.1"
       }
     },
     "npm-prefix": {
@@ -6961,9 +6851,9 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
     "path-type": {
@@ -7129,9 +7019,9 @@
       }
     },
     "prompts": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/prompts/-/prompts-0.1.13.tgz",
-      "integrity": "sha512-5SXno8Svo4bo+aBiY0YjlnjN/ZIwMDz60dADwAxSAonDQiq8WKpB+gnP50D9PgPYtZ1MvpS4RoVa0dX4B9lrcw==",
+      "version": "0.1.14",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-0.1.14.tgz",
+      "integrity": "sha512-rxkyiE9YH6zAz/rZpywySLKkpaj0NMVyNw1qhsubdbjjSgcayjTShDreZGlFMcGSu5sab3bAKPfFk78PB90+8w==",
       "dev": true,
       "requires": {
         "kleur": "^2.0.1",
@@ -7411,9 +7301,9 @@
       }
     },
     "regexpp": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
-      "integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.0.tgz",
+      "integrity": "sha512-g2FAVtR8Uh8GO1Nv5wpxW7VFVwHcCEr4wyA8/MHiRkO8uHoR5ntAA8Uq3P1vvMTX/BeQiRVSpDGLd+Wn5HNOTA==",
       "dev": true
     },
     "regexpu-core": {
@@ -8402,26 +8292,14 @@
       }
     },
     "tar": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.6.tgz",
-      "integrity": "sha512-tMkTnh9EdzxyfW+6GK6fCahagXsnYk6kE6S9Gr9pjVdys769+laCTbodXDhPAjzVtEBazRgP0gYqOjnk9dQzLg==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
       "dev": true,
       "requires": {
-        "chownr": "^1.0.1",
-        "fs-minipass": "^1.2.5",
-        "minipass": "^2.3.3",
-        "minizlib": "^1.1.0",
-        "mkdirp": "^0.5.0",
-        "safe-buffer": "^5.1.2",
-        "yallist": "^3.0.2"
-      },
-      "dependencies": {
-        "yallist": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
-          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-          "dev": true
-        }
+        "block-stream": "*",
+        "fstream": "^1.0.2",
+        "inherits": "2"
       }
     },
     "tar-pack": {
@@ -8438,19 +8316,6 @@
         "rimraf": "^2.5.1",
         "tar": "^2.2.1",
         "uid-number": "^0.0.6"
-      },
-      "dependencies": {
-        "tar": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-          "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-          "dev": true,
-          "requires": {
-            "block-stream": "*",
-            "fstream": "^1.0.2",
-            "inherits": "2"
-          }
-        }
       }
     },
     "tcomb": {
@@ -8609,9 +8474,9 @@
       "dev": true
     },
     "trough": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.2.tgz",
-      "integrity": "sha512-FHkoUZvG6Egrv9XZAyYGKEyb1JMsFphgPjoczkZC2y6W93U1jswcVURB8MUvtsahEPEVACyxD47JAL63vF4JsQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.3.tgz",
+      "integrity": "sha512-fwkLWH+DimvA4YCy+/nvJd61nWQQ2liO/nF/RjkTpiOGi+zxZzVkhb1mvbHIIW4b/8nDsYI8uTmAlc0nNkRMOw==",
       "dev": true
     },
     "tunnel-agent": {
@@ -9188,9 +9053,9 @@
       }
     },
     "validate-npm-package-license": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
-      "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
       "dev": true,
       "requires": {
         "spdx-correct": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "eslint-plugin-babel": "^5.1.0",
     "eslint-plugin-react": "^7.5.1",
     "jest-cli": "^23.4.2",
-    "node-pre-gyp": "^0.10.3",
     "npm-run-all": "^4.1.2",
     "prop-types": "^15.6.0",
     "react": "^16.4.2",


### PR DESCRIPTION
node-pre-gyp, required to build canvas-prebuilt contained a vulnerable dependency
(request->hawk->hoek). Solution: rollback node requirement to >v9.0.0, remove node-pre-gyp

Closes #11