### PR TITLE
Build script

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,5 +1,6 @@
 {
   "branch": "semver",
   "dryRun": true,
-  "debug": true
+  "debug": true,
+  "pkgRoot": "build/pkg"
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "start": "echo TODO",
     "build": "run-s build:*",
     "build:pkg": "babel src --out-dir build/pkg --ignore '**/*.test.js'",
-    "build:files": "cp ./package.json build/pkg/ && cp ./README.md build/pkg/",
+    "build:files": "cp ./package.json build/pkg/ && cp ./README.md build/pkg/ && cp ./LICENSE build/pkg/",
     "test": "run-s -s lint jest",
     "lint": "run-s -s lint:*",
     "lint:js": "eslint --report-unused-disable-directives --ignore-path .gitignore .",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
   "scripts": {
     "clean": "rimraf ./build",
     "start": "echo TODO",
-    "build": "echo TODO",
+    "build": "run-s build:*",
+    "build:pkg": "babel src --out-dir build/pkg --ignore '**/*.test.js'",
+    "build:files": "cp ./package.json build/pkg/ && cp ./README.md build/pkg/",
     "test": "run-s -s lint jest",
     "lint": "run-s -s lint:*",
     "lint:js": "eslint --report-unused-disable-directives --ignore-path .gitignore .",


### PR DESCRIPTION
Added some build scripts to build the src files into `build/pkg`, and copy the `package.json`, `README.md` and `LICENSE` into `build/pkg` also.  Also set the `.releaserc` conf "pkgRoot" to build/pkg so that semantic-release will publish from `build/pkg`