### PR TITLE
feat(XYZ Source): Extending the XYZ source interface

### DIFF
--- a/src/source/xyz.js
+++ b/src/source/xyz.js
@@ -10,9 +10,11 @@ import {SourceCtx} from '.';
 @consumer(LayerCtx)
 class XYZSource extends React.PureComponent {
   static propTypes = {
+    // Context
     layer: PropTypes.object,
+    // Custom
     refreshKey: PropTypes.string,
-
+    // OpenLayers
     attributions: PropTypes.object,
     cacheSize: PropTypes.number,
     crossOrigin: PropTypes.string,
@@ -45,7 +47,9 @@ class XYZSource extends React.PureComponent {
     const {props} = this;
     const {layer} = props;
 
-    this.source = new XYZ({...props, layer: undefined});
+    this.source = new XYZ({
+      ...props, layer: undefined, refreshKey: undefined
+    });
     layer.setSource(this.source);
   }
 
@@ -93,10 +97,11 @@ class XYZSource extends React.PureComponent {
 
   render() {
     const {source, props} = this;
+    const {children} = props;
 
     return (
       <SourceCtx.Provider value={{source}}>
-        {props.children}
+        {children}
       </SourceCtx.Provider>
     );
   }

--- a/src/source/xyz.js
+++ b/src/source/xyz.js
@@ -12,8 +12,7 @@ class XYZSource extends React.PureComponent {
   static propTypes = {
     // Context
     layer: PropTypes.object,
-    // Custom
-    refreshKey: PropTypes.string,
+
     // OpenLayers
     attributions: PropTypes.object,
     cacheSize: PropTypes.number,
@@ -39,8 +38,6 @@ class XYZSource extends React.PureComponent {
     super(props);
     this.generateSource();
     this.syncTileFuncs();
-
-    this.refreshKey = props.refreshKey;
   }
 
   generateSource() {
@@ -94,13 +91,7 @@ class XYZSource extends React.PureComponent {
   }
 
   componentDidUpdate() {
-    const {refreshKey} = this.props;
     this.syncProps();
-
-    if (this.refreshKey !== refreshKey) {
-      this.refreshKey = refreshKey;
-      this.source.refresh();
-    }
   }
 
   render() {

--- a/src/source/xyz.js
+++ b/src/source/xyz.js
@@ -11,13 +11,25 @@ import {SourceCtx} from '.';
 class XYZSource extends React.PureComponent {
   static propTypes = {
     layer: PropTypes.object,
-    tileSize: PropTypes.array,
-    tileGrid: PropTypes.object,
+    refreshKey: PropTypes.string,
+
+    attributions: PropTypes.object,
+    cacheSize: PropTypes.number,
+    crossOrigin: PropTypes.string,
+    opaque: PropTypes.bool,
     projection: PropTypes.object,
+    reprojectionErrorThreshold: PropTypes.number,
+    maxZoom: PropTypes.number,
+    minZoom: PropTypes.number,
+    tileGrid: PropTypes.object,
+    tileLoadFunction: PropTypes.func,
+    tilePixelRatio: PropTypes.number,
+    tileUrlFunction: PropTypes.func,
+    tileSize: PropTypes.array,
     url: PropTypes.string,
     urls: PropTypes.array,
-    tileUrlFunction: PropTypes.func,
-    tileLoadFunction: PropTypes.func
+    wrapX: PropTypes.bool,
+    transition: PropTypes.number
   };
 
 
@@ -25,18 +37,15 @@ class XYZSource extends React.PureComponent {
     super(props);
     this.generateSource();
     this.syncTileFuncs();
+
+    this.refreshKey = props.refreshKey;
   }
 
   generateSource() {
-    const {layer, tileSize, tileGrid, url, urls, projection} = this.props;
+    const {props} = this;
+    const {layer} = props;
 
-    this.source = new XYZ({
-      tileSize,
-      tileGrid,
-      projection,
-      url,
-      urls
-    });
+    this.source = new XYZ({...props, layer: undefined});
     layer.setSource(this.source);
   }
 
@@ -73,7 +82,13 @@ class XYZSource extends React.PureComponent {
   }
 
   componentDidUpdate() {
+    const {refreshKey} = this.props;
     this.syncProps();
+
+    if (refreshKey !== undefined && this.refreshKey !== refreshKey) {
+      this.refreshKey = refreshKey;
+      this.source.refresh();
+    }
   }
 
   render() {

--- a/src/source/xyz.js
+++ b/src/source/xyz.js
@@ -45,10 +45,18 @@ class XYZSource extends React.PureComponent {
 
   generateSource() {
     const {props} = this;
-    const {layer} = props;
+    const {
+      layer, attributions, cacheSize, crossOrigin, opaque,
+      projection, reprojectionErrorThreshold, maxZoom, minZoom,
+      tileGrid, tileLoadFunction, tilePixelRatio, tileUrlFunction,
+      tileSize, url, urls, wrapX, transition
+    } = props;
 
     this.source = new XYZ({
-      ...props, layer: undefined, refreshKey: undefined
+      attributions, cacheSize, crossOrigin, opaque,
+      projection, reprojectionErrorThreshold, maxZoom, minZoom,
+      tileGrid, tileLoadFunction, tilePixelRatio, tileUrlFunction,
+      tileSize, url, urls, wrapX, transition
     });
     layer.setSource(this.source);
   }

--- a/src/source/xyz.js
+++ b/src/source/xyz.js
@@ -89,7 +89,7 @@ class XYZSource extends React.PureComponent {
     const {refreshKey} = this.props;
     this.syncProps();
 
-    if (refreshKey !== undefined && this.refreshKey !== refreshKey) {
+    if (this.refreshKey !== refreshKey) {
       this.refreshKey = refreshKey;
       this.source.refresh();
     }

--- a/src/source/xyz.test.js
+++ b/src/source/xyz.test.js
@@ -103,11 +103,12 @@ describe('<XYZSource />', ()=> {
 
 
   it('uses tileUrlFunction', ()=> {
+    const layer = new OlTileLayer();
     const tileUrlFunction = jest.fn();
     renderer.create(
       <XYZSource layer={layer} tileUrlFunction={tileUrlFunction} />
     );
-    const [[source]] = layer.setSource.mock.calls;
+    const source = layer.getSource();
 
     source.getTileUrlFunction()([0, 0], 1);
 
@@ -116,15 +117,90 @@ describe('<XYZSource />', ()=> {
 
 
   it('uses tileLoadFunction', ()=> {
+    const layer = new OlTileLayer();
     const tileLoadFunction = jest.fn();
     renderer.create(
       <XYZSource layer={layer} tileLoadFunction={tileLoadFunction} />
     );
-    const [[source]] = layer.setSource.mock.calls;
+    const source = layer.getSource();
     const tile = {};
 
     source.getTileLoadFunction()(tile, 'tile-url');
 
     expect(tileLoadFunction).toHaveBeenCalledWith(tile, 'tile-url');
+  });
+});
+
+
+describe('<XYZSource /> - source initialization', ()=> {
+  // eslint-disable-next-line max-statements
+  it('passes props to source initialization', ()=> {
+    const attributions = {};
+    const cacheSize = 1;
+    const crossOrigin = 'test-origin';
+    const opaque = true;
+    const projection = {};
+    const reprojectionErrorThreshold = 2;
+    const maxZoom = 3;
+    const minZoom = 4;
+    const tileGrid = {};
+    const tileLoadFunction = jest.fn();
+    const tilePixelRatio = 5;
+    const tileUrlFunction = jest.fn();
+    const tileSize = [];
+    const url = 'test-url.com';
+    const urls = ['test-url.com'];
+    const wrapX = false;
+    const transition = 6;
+
+    const layer = new OlTileLayer();
+    renderer.create(
+      <XYZSource
+        layer={layer}
+        attributions={attributions}
+        cacheSize={cacheSize}
+        crossOrigin={crossOrigin}
+        opaque={opaque}
+        projection={projection}
+        reprojectionErrorThreshold={reprojectionErrorThreshold}
+        maxZoom={maxZoom}
+        minZoom={minZoom}
+        tileGrid={tileGrid}
+        tileLoadFunction={tileLoadFunction}
+        tilePixelRatio={tilePixelRatio}
+        tileUrlFunction={tileUrlFunction}
+        tileSize={tileSize}
+        url={url}
+        urls={urls}
+        wrapX={wrapX}
+        transition={transition}
+      />
+    );
+
+    expect(XYZ).toHaveBeenCalledWith({
+      attributions, cacheSize, crossOrigin, opaque,
+      projection, reprojectionErrorThreshold, maxZoom, minZoom,
+      tileGrid, tileLoadFunction, tilePixelRatio, tileUrlFunction,
+      tileSize, url, urls, wrapX, transition
+    });
+  });
+});
+
+
+describe('<XYZSource /> - refresh key', ()=> {
+  it('can be refreshed by changing the refresh key', ()=> {
+    const layer = new OlTileLayer();
+    const projection = getProjection('EPSG:3857');
+    const rendered = renderer.create(
+      <XYZSource layer={layer} projection={projection} refreshKey={undefined} />
+    );
+
+    const spy = jest.spyOn(layer.getSource(), 'refresh');
+
+    rendered.update(
+      <XYZSource layer={layer} projection={projection} refreshKey={'test'} />
+    );
+
+    expect(spy).toHaveBeenCalled();
   });
 });

--- a/src/source/xyz.test.js
+++ b/src/source/xyz.test.js
@@ -192,13 +192,17 @@ describe('<XYZSource /> - refresh key', ()=> {
     const layer = new OlTileLayer();
     const projection = getProjection('EPSG:3857');
     const rendered = renderer.create(
-      <XYZSource layer={layer} projection={projection} refreshKey={undefined} />
+      <XYZSource
+        layer={layer} projection={projection} refreshKey={'first-key'}
+      />
     );
 
     const spy = jest.spyOn(layer.getSource(), 'refresh');
 
     rendered.update(
-      <XYZSource layer={layer} projection={projection} refreshKey={'test'} />
+      <XYZSource
+        layer={layer} projection={projection} refreshKey={'second-key'}
+      />
     );
 
     expect(spy).toHaveBeenCalled();

--- a/src/source/xyz.test.js
+++ b/src/source/xyz.test.js
@@ -185,26 +185,3 @@ describe('<XYZSource /> - source initialization', ()=> {
     });
   });
 });
-
-
-describe('<XYZSource /> - refresh key', ()=> {
-  it('can be refreshed by changing the refresh key', ()=> {
-    const layer = new OlTileLayer();
-    const projection = getProjection('EPSG:3857');
-    const rendered = renderer.create(
-      <XYZSource
-        layer={layer} projection={projection} refreshKey={'first-key'}
-      />
-    );
-
-    const spy = jest.spyOn(layer.getSource(), 'refresh');
-
-    rendered.update(
-      <XYZSource
-        layer={layer} projection={projection} refreshKey={'second-key'}
-      />
-    );
-
-    expect(spy).toHaveBeenCalled();
-  });
-});


### PR DESCRIPTION
Users can now pass initialization options for the OpenLayers XYZ source class via props on the OLR XYZSource component:


```html
<XYZSource cacheSize={1024} url={'some-url.com'} ...\>
``` 

All the OpenLayers XYZ init options are mapped to the components props.

Closes #43